### PR TITLE
updated 'happy path' ternary option for dynamic network acls block

### DIFF
--- a/Terraform/Modules/Azure_Openai/azure_openai.tf
+++ b/Terraform/Modules/Azure_Openai/azure_openai.tf
@@ -13,7 +13,7 @@ resource "azurerm_cognitive_account" "main" {
   custom_subdomain_name = var.cog_account_name
 
   dynamic "network_acls" {
-    for_each = try(var.private_networking.enabled, true) ? [var.private_networking.enabled] : []
+    for_each = try(var.private_networking.enabled, true) ? [var.private_networking] : []
 
     content {
       default_action = "Deny"


### PR DESCRIPTION
bools can't be iterated over, so `private_networking.enabled` can't be an option for the for each array. changed it to the full `private_networking` object.